### PR TITLE
Hotfix : duplicated concept bug

### DIFF
--- a/app/harvesters/hal/hal_references_converter.py
+++ b/app/harvesters/hal/hal_references_converter.py
@@ -25,10 +25,13 @@ class HalReferencesConverter:
         [  # pylint: disable=expression-not-assigned
             new_ref.subtitles.append(subtitle) for subtitle in self._subtitles(raw_data)
         ]
-        [  # pylint: disable=expression-not-assigned
-            new_ref.subjects.append(subject)
-            async for subject in self._subjects(raw_data)
-        ]
+        async for subject in self._subjects(raw_data):
+            # Concept from hal may be repeated, avoid duplicates
+            if subject.id is None or subject.id not in list(
+                map(lambda s: s.id, new_ref.subjects)
+            ):
+                new_ref.subjects.append(subject)
+
         new_ref.hash = self._hash(raw_data)
         new_ref.source_identifier = raw_data["docid"]
         return new_ref

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -282,6 +282,16 @@ def fixture_hal_api_docs_for_one_researcher(_base_path):
     return _hal_api_json_data_from_file(_base_path, "docs_for_one_researcher")
 
 
+@pytest.fixture(name="hal_api_docs_with_same_kw_twice")
+def fixture_hal_api_docs_with_same_kw_twice(_base_path):
+    """
+    Generate a HAL API response for one researcher in JSON format
+    :param _base_path: test data directory base
+    :return: HAL API response for one researcher in JSON format
+    """
+    return _hal_api_json_data_from_file(_base_path, "docs_with_same_kw_twice")
+
+
 def _hal_api_json_data_from_file(base_path, file_name):
     file_path = f"data/hal_api/{file_name}.json"
     return _json_data_from_file(base_path, file_path)

--- a/tests/data/hal_api/docs_with_same_kw_twice.json
+++ b/tests/data/hal_api/docs_with_same_kw_twice.json
@@ -1,0 +1,109 @@
+{
+  "response": {
+    "numFound": 97,
+    "start": 0,
+    "numFoundExact": true,
+    "docs": [
+      {
+        "docid": "1299757",
+        "citationRef_s": "<i>Journal of International Economics</i>, 2015, 97 (1), pp.29-44. <a target=\"_blank\" href=\"https://dx.doi.org/10.1016/j.jinteco.2015.04.008\">&#x27E8;10.1016/j.jinteco.2015.04.008&#x27E9;</a>",
+        "citationFull_s": "Lionel Fontagné, Gianluca Orefice, Roberta Piermartini, Nadia Rocha. Product Standards and Margins of Trade: Firm-Level Evidence Product Standards and Margins of Trade: Firm-Level Evidence. <i>Journal of International Economics</i>, 2015, 97 (1), pp.29-44. <a target=\"_blank\" href=\"https://dx.doi.org/10.1016/j.jinteco.2015.04.008\">&#x27E8;10.1016/j.jinteco.2015.04.008&#x27E9;</a>. <a target=\"_blank\" href=\"https://hal.science/hal-01299757\">&#x27E8;hal-01299757&#x27E9;</a>",
+        "en_title_s": [
+          "Product Standards and Margins of Trade: Firm-Level Evidence Product Standards and Margins of Trade: Firm-Level Evidence"
+        ],
+        "en_keyword_s": [
+          "International trade"
+        ],
+        "en_abstract_s": [
+          "This paper considers the heterogenous trade effects of restrictive Sanitary and Phyto-Sanitary (SPS) measures on exporters of different sizes, and the channels via which aggregate exports fall: firm participation, export values and pricing strategies. We do so by matching a detailed panel of French firm exports to a new database of SPS regulatory measures that have been raised as of concern in the dedicated committees of the WTO. By using specific trade concerns to capture the restrictiveness of product standards, we focus only on standards that are perceived as trade barriers. We analyze their effects on three trade-related outcomes: (i) the probability to export and to exit the export market (the firm-product extensive margin), (ii) the value exported (the firm-product intensive margin), and (iii) export prices. We find that SPS concerns discourage the presence of exporters in SPS-imposing foreign markets. We also find a negative effect of SPS imposition on the intensive margins of trade. These negative effects SPS are attenuated in larger firms."
+        ],
+        "authIdForm_i": [
+          6574,
+          951488,
+          1139367,
+          1145946
+        ],
+        "authFullNameFormIDPersonIDIDHal_fs": [
+          "Lionel Fontagné_FacetSep_6574-6113_FacetSep_lionelfontagne",
+          "Gianluca Orefice_FacetSep_951488-0_FacetSep_",
+          "Roberta Piermartini_FacetSep_1139367-0_FacetSep_",
+          "Nadia Rocha_FacetSep_1145946-0_FacetSep_"
+        ],
+        "authIdHasStructure_fs": [
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_301309_FacetSep_Paris School of Economics",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_7550_FacetSep_Université Paris 1 Panthéon-Sorbonne",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_59704_FacetSep_École normale supérieure - Paris",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_564132_FacetSep_Université Paris sciences et lettres",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_99539_FacetSep_École des hautes études en sciences sociales",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_301545_FacetSep_École des Ponts ParisTech",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_441569_FacetSep_Centre National de la Recherche Scientifique",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_577435_FacetSep_Institut National de Recherche pour l’Agriculture, l’Alimentation et l’Environnement",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_15080_FacetSep_Centre d'économie de la Sorbonne",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_7550_FacetSep_Université Paris 1 Panthéon-Sorbonne",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_441569_FacetSep_Centre National de la Recherche Scientifique",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_39083_FacetSep_Centre d'Etudes Prospectives et d'Informations Internationales",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_309406_FacetSep_Centre d'analyse stratégique",
+          "951488-0_FacetSep_Gianluca Orefice_JoinSep_379791_FacetSep_Centre d'Etudes Prospectives et d'Informations Internationales",
+          "1139367-0_FacetSep_Roberta Piermartini_JoinSep_313299_FacetSep_WTO",
+          "1145946-0_FacetSep_Nadia Rocha_JoinSep_313299_FacetSep_WTO"
+        ],
+        "labStructId_i": [
+          15080,
+          39083
+        ],
+        "docType_s": "ART",
+        "publicationDate_tdate": "2015-09-01T00:00:00Z"
+      },
+      {
+        "docid": "1416567",
+        "citationRef_s": "<i>The World Economy</i>, 2017, 40 (1), pp.36-55. <a target=\"_blank\" href=\"https://dx.doi.org/10.1111/twec.12479\">&#x27E8;10.1111/twec.12479&#x27E9;</a>",
+        "citationFull_s": "Lionel Fontagné, Jean Fouré, Alexander Keck. Simulating World Trade in the Decades Ahead: Driving Forces and Policy Implications. <i>The World Economy</i>, 2017, 40 (1), pp.36-55. <a target=\"_blank\" href=\"https://dx.doi.org/10.1111/twec.12479\">&#x27E8;10.1111/twec.12479&#x27E9;</a>. <a target=\"_blank\" href=\"https://hal.science/hal-01416567\">&#x27E8;hal-01416567&#x27E9;</a>",
+        "en_title_s": [
+          "Simulating World Trade in the Decades Ahead: Driving Forces and Policy Implications"
+        ],
+        "en_keyword_s": [
+          "International trade",
+          "Financial crisis",
+          "International trade"
+        ],
+        "en_abstract_s": [
+          "Notwithstanding the current slowdown, the geography and composition of international trade are changing fast. We link a macroeconomic growth model and sectoral computable general equilibrium framework in order to project the world economy forward to the year 2035 and assess to what extent current trends in trade are expected to continue. Constructing fully traceable scenarios based on assumptions grounded in the literature, we are also able to isolate the relative impact of key economic drivers. We find that the stakes for developing countries are particularly high: the emergence of new players in the world economy, intensification of South–South trade and diversification into skill-intensive activities may continue only in a dynamic economic and open trade environment. Current trends towards increased regionalisation may be reversed, with multilateral trade relationships gaining in importance. Hypothetical mega-regionals could slow down, but not frustrate the prevalence of multilateralism. Continuing technological progress is likely to have the biggest impact on future economic developments around the globe. Population dynamics are influential as well: for some countries, upskilling will be crucial; for others, labour shortages may be addressed through migration. Several developing countries would benefit from increased capital mobility; others will only diversify into dynamic sectors, when trade costs are further reduced."
+        ],
+        "authIdForm_i": [
+          6574,
+          629095,
+          395289
+        ],
+        "authFullNameFormIDPersonIDIDHal_fs": [
+          "Lionel Fontagné_FacetSep_6574-6113_FacetSep_lionelfontagne",
+          "Jean Fouré_FacetSep_629095-0_FacetSep_",
+          "Alexander Keck_FacetSep_395289-0_FacetSep_"
+        ],
+        "authIdHasStructure_fs": [
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_301309_FacetSep_Paris School of Economics",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_7550_FacetSep_Université Paris 1 Panthéon-Sorbonne",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_59704_FacetSep_École normale supérieure - Paris",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_564132_FacetSep_Université Paris sciences et lettres",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_99539_FacetSep_École des hautes études en sciences sociales",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_301545_FacetSep_École des Ponts ParisTech",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_441569_FacetSep_Centre National de la Recherche Scientifique",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_577435_FacetSep_Institut National de Recherche pour l’Agriculture, l’Alimentation et l’Environnement",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_15080_FacetSep_Centre d'économie de la Sorbonne",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_7550_FacetSep_Université Paris 1 Panthéon-Sorbonne",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_441569_FacetSep_Centre National de la Recherche Scientifique",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_39083_FacetSep_Centre d'Etudes Prospectives et d'Informations Internationales",
+          "6574-6113_FacetSep_Lionel Fontagné_JoinSep_309406_FacetSep_Centre d'analyse stratégique",
+          "629095-0_FacetSep_Jean Fouré_JoinSep_39083_FacetSep_Centre d'Etudes Prospectives et d'Informations Internationales",
+          "629095-0_FacetSep_Jean Fouré_JoinSep_309406_FacetSep_Centre d'analyse stratégique",
+          "395289-0_FacetSep_Alexander Keck_JoinSep_313299_FacetSep_WTO"
+        ],
+        "labStructId_i": [
+          15080,
+          39083
+        ],
+        "docType_s": "ART",
+        "publicationDate_tdate": "2017-01-01T00:00:00Z"
+      }
+    ]
+  }
+}

--- a/tests/test_harvesters/test_hal/test_hal_harvester.py
+++ b/tests/test_harvesters/test_hal/test_hal_harvester.py
@@ -5,9 +5,10 @@ import aiohttp
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
 
 from app.config import get_app_settings
-from app.db.models import Reference, ReferenceEvent, Harvesting
+from app.db.models import Reference, ReferenceEvent, Harvesting, Concept, Label
 from app.db.references.references_recorder import ReferencesRecorder
 from app.harvesters.hal.hal_harvester import HalHarvester
 from app.harvesters.hal.hal_references_converter import HalReferencesConverter
@@ -19,8 +20,21 @@ def fixture_hal_api_client_mock(hal_api_docs_for_one_researcher: dict):
     """Retrieval service mock to detect run method calls."""
     with mock.patch.object(aiohttp.ClientSession, "get") as aiohttp_client_session_get:
         aiohttp_client_session_get.return_value.__aenter__.return_value.status = 200
-        aiohttp_client_session_get.return_value.__aenter__.return_value.json.return_value \
-            = hal_api_docs_for_one_researcher
+        aiohttp_client_session_get.return_value.__aenter__.return_value.json.return_value = (
+            hal_api_docs_for_one_researcher
+        )
+
+        yield aiohttp_client_session_get
+
+
+@pytest.fixture(name="hal_api_client_mock_same_kw_twice")
+def fixture_hal_api_client_mock_same_kw_twice(hal_api_docs_with_same_kw_twice: dict):
+    """Retrieval service mock to detect run method calls."""
+    with mock.patch.object(aiohttp.ClientSession, "get") as aiohttp_client_session_get:
+        aiohttp_client_session_get.return_value.__aenter__.return_value.status = 200
+        aiohttp_client_session_get.return_value.__aenter__.return_value.json.return_value = (
+            hal_api_docs_with_same_kw_twice
+        )
 
         yield aiohttp_client_session_get
 
@@ -28,7 +42,9 @@ def fixture_hal_api_client_mock(hal_api_docs_for_one_researcher: dict):
 @pytest.fixture(name="reference_recorder_register_mock")
 def fixture_reference_recorder_register_mock():
     """Reference recorder mock to detect register method calls."""
-    with mock.patch.object(ReferencesRecorder, "register") as reference_recorder_register_mock:
+    with mock.patch.object(
+        ReferencesRecorder, "register"
+    ) as reference_recorder_register_mock:
         yield reference_recorder_register_mock
 
 
@@ -40,33 +56,37 @@ def fixture_hal_harvester() -> HalHarvester:
 
 
 def test_hal_harvester_relevant_for_person_with_idhal(
-        person_with_name_and_id_hal_i: Person,
-        hal_harvester: HalHarvester,
+    person_with_name_and_id_hal_i: Person,
+    hal_harvester: HalHarvester,
 ):
     """Test that the harvester will run if submitted with an IDHAL."""
     assert hal_harvester.is_relevant(person_with_name_and_id_hal_i) is True
 
 
 def test_hal_harvester_not_relevant_for_person_with_idref_only(
-        person_with_name_and_idref: Person,
-        hal_harvester: HalHarvester,
+    person_with_name_and_idref: Person,
+    hal_harvester: HalHarvester,
 ):
     """Test that the harvester will not run if submitted with only an IDREF."""
     assert hal_harvester.is_relevant(person_with_name_and_idref) is False
 
 
 def test_hal_harvester_not_relevant_for_person_with_last_name_and_first_name_only(
-        person_with_last_name_and_first_name: Person,
-        hal_harvester: HalHarvester,
+    person_with_last_name_and_first_name: Person,
+    hal_harvester: HalHarvester,
 ):
     """Test that the harvester will not run if submitted with only a last name."""
     assert hal_harvester.is_relevant(person_with_last_name_and_first_name) is False
 
 
 @pytest.mark.asyncio
-async def test_hal_harvester_finds_doc(hal_harvester: HalHarvester, hal_harvesting_db_model,
-                                       reference_recorder_register_mock, hal_api_client_mock,
-                                       async_session: AsyncSession):
+async def test_hal_harvester_finds_doc(
+    hal_harvester: HalHarvester,
+    hal_harvesting_db_model,
+    reference_recorder_register_mock,
+    hal_api_client_mock,
+    async_session: AsyncSession,
+):
     """Test that the harvester will find documents."""
     async_session.add(hal_harvesting_db_model)
     await async_session.commit()
@@ -78,11 +98,13 @@ async def test_hal_harvester_finds_doc(hal_harvester: HalHarvester, hal_harvesti
 
 
 @pytest.mark.asyncio
-async def test_hal_harvester_registers_docs_in_db(hal_harvester: HalHarvester,
-                                                  hal_harvesting_db_model,
-                                                  hal_api_client_mock,
-                                                  hal_api_docs_for_one_researcher: dict,
-                                                  async_session: AsyncSession):
+async def test_hal_harvester_registers_docs_in_db(
+    hal_harvester: HalHarvester,
+    hal_harvesting_db_model,
+    hal_api_client_mock,
+    hal_api_docs_for_one_researcher: dict,
+    async_session: AsyncSession,
+):
     """Test that after harvesting, the references are registered in the database."""
     async_session.add(hal_harvesting_db_model)
     await async_session.commit()
@@ -90,15 +112,62 @@ async def test_hal_harvester_registers_docs_in_db(hal_harvester: HalHarvester,
     hal_harvester.set_entity_id(hal_harvesting_db_model.retrieval.entity_id)
     await hal_harvester.run()
     hal_api_client_mock.assert_called_once()
-    stmt = select(Reference, ReferenceEvent).join(ReferenceEvent).join(Harvesting).filter(
-        Harvesting.id == hal_harvesting_db_model.id)
+    stmt = (
+        select(Reference, ReferenceEvent)
+        .join(ReferenceEvent)
+        .join(Harvesting)
+        .filter(Harvesting.id == hal_harvesting_db_model.id)
+    )
     result = (await async_session.execute(stmt)).unique()
     results = list(result)
     assert len(results) == 1
     reference = results[0][0]
     reference_event = results[0][1]
-    assert reference.titles[0].value == \
-           hal_api_docs_for_one_researcher.get('response').get('docs')[0].get('en_title_s')[0]
-    assert reference.source_identifier == \
-           hal_api_docs_for_one_researcher.get('response').get('docs')[0].get('docid')
+    assert (
+        reference.titles[0].value
+        == hal_api_docs_for_one_researcher.get("response")
+        .get("docs")[0]
+        .get("en_title_s")[0]
+    )
+    assert reference.source_identifier == hal_api_docs_for_one_researcher.get(
+        "response"
+    ).get("docs")[0].get("docid")
     assert reference_event.type == ReferenceEvent.Type.CREATED.value
+
+
+@pytest.mark.asyncio
+async def test_hal_harvester_registers_one_kw_for_two_occurences(
+    hal_harvester: HalHarvester,
+    hal_harvesting_db_model,
+    hal_api_client_mock_same_kw_twice,
+    async_session: AsyncSession,
+):
+    """
+    The first publication has a concept,
+    and the same concept is mentioned twice in a later publication.
+    """
+    async_session.add(hal_harvesting_db_model)
+    await async_session.commit()
+    hal_harvester.set_harvesting_id(hal_harvesting_db_model.id)
+    hal_harvester.set_entity_id(hal_harvesting_db_model.retrieval.entity_id)
+    await hal_harvester.run()
+    hal_api_client_mock_same_kw_twice.assert_called_once()
+    stmt = (
+        select(Reference)
+        .options(joinedload(Reference.subjects).joinedload(Concept.labels))
+        .join(Concept, Reference.subjects)
+        .join(Label, Concept.labels)
+        .join(ReferenceEvent)
+        .join(Harvesting)
+        .filter(Harvesting.id == hal_harvesting_db_model.id)
+    )
+    result = (await async_session.execute(stmt)).unique()
+    results = list(result)
+    first_result_subjects = results[0][0].subjects
+    second_result_subjects = results[1][0].subjects
+    assert len(results) == 2
+    assert len(first_result_subjects) == 1
+    # there should be only one concept created for the two occurences of the same keyword
+    assert len(second_result_subjects) == 2
+    assert second_result_subjects[0].labels[0].value == "International trade"
+    assert second_result_subjects[0] == first_result_subjects[0]


### PR DESCRIPTION
Prevent sqlalchemy failure when a publication comes with a concept that is duplicated and that already exists in database